### PR TITLE
Добавлена поддержка локального SMTP-сервера на базе Docker Mailserver

### DIFF
--- a/deploy/examples/README.md
+++ b/deploy/examples/README.md
@@ -6,9 +6,10 @@
 
 Файлы приложения (`/app/data`: тарифы, темы, логотипы) монтируются из папки `data` рядом с выбранным `docker-compose.yml`. Для кастомных тем создайте `data/themes`.
 
-| Папка | Документация |
-| --- | --- |
-| `caddy` | [Развертывание с Caddy](../../docs/getting-started/deployment.md#caddy-рекомендуемый-вариант) |
-| `nginx` | [Развертывание с Nginx](../../docs/getting-started/deployment.md#nginx) |
-| `newt` | [Развертывание через Pangolin / Newt](../../docs/getting-started/deployment.md#pangolin--newt) |
-| `no-proxy` | [Запуск без обратного прокси](../../docs/getting-started/deployment.md#без-обратного-прокси) |
+| Папка   | Документация                                                                                                                                           |
+| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `caddy`    | [Развертывание с Caddy](../../docs/getting-started/deployment.md#caddy-рекомендуемый-вариант)                                       |
+| `nginx`    | [Развертывание с Nginx](../../docs/getting-started/deployment.md#nginx)                                                                                 |
+| `newt`     | [Развертывание через Pangolin / Newt](../../docs/getting-started/deployment.md#pangolin--newt)                                                      |
+| `no-proxy` | [Запуск без обратного прокси](../../docs/getting-started/deployment.md#без-обратного-прокси)                                |
+| `mail`     | [Развертывание локального SMTP-сервера](../../docs/features/email-login.md#настройка-локального-smtp-сервера) |

--- a/deploy/examples/mail/docker-compose.yml
+++ b/deploy/examples/mail/docker-compose.yml
@@ -1,0 +1,26 @@
+services:
+  mailserver:
+    image: ghcr.io/docker-mailserver/docker-mailserver:latest
+    container_name: mailserver
+    hostname: mail.example.com # Замените на ваш реальный домен (оставить поддомен mail)
+    domainname: example.com # Замените на ваш реальный домен
+    ports:
+      - "25:25"
+      - "587:587"
+      - "465:465"
+      - "993:993"
+    volumes:
+      - ./mail-data:/var/mail
+      - ./config:/tmp/docker-mailserver
+    environment:
+      - SSL_TYPE=manual
+      - SSL_CERT_PATH=path/to/your/crt/file/example.com.crt # Путь к файлу сертификата
+      - SSL_KEY_PATH=path/to/your/key/file/example.com.key # Путь к закрытому ключу
+      - OVERRIDE_HOSTNAME=mail.example.com # Замените на ваш реальный домен
+      - PERMIT_DOCKER=network
+      - ENABLE_OPENDKIM=0
+      - ENABLE_OPENDMARC=0
+      - ENABLE_AMAVIS=0
+      - ENABLE_CLAMAV=0
+      - ENABLE_SPAMASSASSIN=0
+    restart: always

--- a/docs/features/email-login.md
+++ b/docs/features/email-login.md
@@ -106,3 +106,54 @@ docker compose logs -f backend
 - Пользователь получает `rate_limited`: подождите `EMAIL_CODE_RESEND_SECONDS` или проверьте brute-force настройки.
 
 Email-уведомления поддержки, платежей и жизненного цикла подписки используют тот же SMTP-контур. Сценарий поддержки описан в [разделе тикетов](support.md), сводка по каналам - в разделе [уведомления](notifications.md).
+
+## Настройка локального SMTP-сервера
+
+### Требования
+
+Перед запуском локального SMTP-сервера вам потребуется настроить DNS-записи вашего домена:
+
+* A — mail.example.com (указать IP вашего сервера)
+* MX — mail.example.com (приоритет 10)
+* PTR — mail.example.com (настраивается у вашего хостера VPS)
+* TXT — `v=spf1 ip4:1.2.3.4 ~all` (поддомен @, замените `1.2.3.4` на реальный ipv4 вашего сервера)
+
+После изменения DNS-записей подождите некоторое время (иногда требуется от 3 часов до суток) для применения изменений.
+
+Для использования STARTTLS необходимо получить TLS/SSL-сертификат для домена mail.example.com. Самый простой способ это сделать — прописать следующую директиву в Caddyfile (если вы используете Caddy):
+
+```Caddyfile
+https://mail.example.com {
+    respond "Mail server"
+}
+```
+
+### Установка
+
+1. Настройка docker-compose.yml:
+
+```bash
+mkdir -p /opt/mailserver
+cd /opt/mailserver
+curl -O https://github.com/3252a8/remnawave-minishop/blob/main/deploy/examples/mail/docker-compose.yml
+nano docker-compose.yml
+```
+
+2. Запуск:
+
+```bash
+docker compose up -d
+```
+3. Создание пользователя:
+```bash
+# Скрипт попросит придумать пароль и потвердить его
+docker exec -it mailserver setup email add no-reply@example.com
+
+# Проверка создания пользователя
+docker exec -it mailserver setup email list
+
+# Должны увидеть:
+# no-reply@example.com
+```
+
+После всех настроек вы можете использовать свой почтовый клиент (Microsoft Outlook, Mozilla Thunderbird) для отправки и получения писем. В окне добавления нового аккаунта достаточно ввести созданную почту no-reply@example.com и пароль.

--- a/docs/features/email-login.md
+++ b/docs/features/email-login.md
@@ -135,7 +135,7 @@ https://mail.example.com {
 ```bash
 mkdir -p /opt/mailserver
 cd /opt/mailserver
-curl -O https://github.com/3252a8/remnawave-minishop/blob/main/deploy/examples/mail/docker-compose.yml
+curl -O https://raw.githubusercontent.com/3252a8/remnawave-minishop/refs/heads/main/deploy/examples/mail/docker-compose.yml
 nano docker-compose.yml
 ```
 
@@ -144,7 +144,9 @@ nano docker-compose.yml
 ```bash
 docker compose up -d
 ```
+
 3. Создание пользователя:
+
 ```bash
 # Скрипт попросит придумать пароль и потвердить его
 docker exec -it mailserver setup email add no-reply@example.com


### PR DESCRIPTION
Этот пул-реквест добавляет в проект возможность развертывания собственного почтового сервера, что позволяет отправлять транзакционные письма (уведомления о платежах, поддержке, статусе подписки) через локальную SMTP-инфраструктуру, не завися от внешних провайдеров.

### 📦 Основные изменения

| Файл | Тип изменения | Описание |
|------|--------------|----------|
| `deploy/examples/mail/docker-compose.yml` | ➕ Добавлен | Полноценная конфигурация Docker Compose для развертывания `docker-mailserver` с поддержкой SMTP, IMAP, STARTTLS |
| `docs/features/email-login.md` | 📝 Дополнен | Добавлен новый раздел **«Настройка локального SMTP-сервера»** с описанием требований, установки и создания пользователя |

### ⚙️ Детали Docker-конфигурации

Добавлен файл `deploy/examples/mail/docker-compose.yml`, включающий:

* Образ `ghcr.io/docker-mailserver/docker-mailserver:latest`
* Проброс портов: `25`, `587`, `465`, `993`
* Монтирование томов для почтовых данных и конфигурации
* Переменные окружения для ручного SSL (пути к сертификату и ключу)
* Настройки безопасности с отключением ресурсоемких сервисов: `ENABLE_OPENDKIM=0`, `ENABLE_OPENDMARC=0`, `ENABLE_AMAVIS=0`, `ENABLE_CLAMAV=0`, `ENABLE_SPAMASSASSIN=0`

### 📖 Обновления документации

В `email-login.md` добавлен подробный раздел, содержащий:

* **Требования к DNS-записям**: A, MX, PTR и SPF записи для корректной доставки почты
* **Получение SSL-сертификата**: пример настройки через Caddy для поддержки STARTTLS
* **Инструкция по установке**: команды для создания директории, загрузки `docker-compose.yml` и запуска контейнера
* **Создание пользователя**: пример команды для добавления почтового ящика `no-reply@example.com` и проверки его наличия

### ✅ Как тестировать

1. Подготовьте домен и настройте DNS-записи согласно документации
2. Получите SSL-сертификат для вашего домена
3. Выполните команды установки:
   ```bash
   mkdir -p /opt/mailserver
   cd /opt/mailserver
   curl -O https://raw.githubusercontent.com/austnv/remnawave-minishop/refs/heads/main/deploy/examples/mail/docker-compose.yml
   docker compose up -d
   ```
4. Создайте тестового пользователя:
   ```bash
   docker exec -it mailserver setup email add no-reply@example.com
   ```
5. Подключитесь к почтовому серверу через любой почтовый клиент, используя созданные учетные данные

### 🔗 Связанные задачи

N/A