### PR TITLE
fix(sync): treat LIMITED panel status as an active subscription

### DIFF
--- a/backend/bot/handlers/admin/sync_admin_runner.py
+++ b/backend/bot/handlers/admin/sync_admin_runner.py
@@ -7,7 +7,10 @@ from sqlalchemy import or_, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from bot.middlewares.i18n import JsonI18n
-from bot.services.panel_activity import panel_user_last_connected_datetime
+from bot.services.panel_activity import (
+    panel_status_means_active,
+    panel_user_last_connected_datetime,
+)
 from bot.services.panel_api_service import PanelApiService
 from config.settings import Settings
 from db.advisory_locks import acquire_subscription_background_sync_lock
@@ -594,7 +597,7 @@ async def _perform_sync_impl(
 
                         if subscription_uuid_from_panel:
                             # If the panel reports the subscription as ACTIVE, deactivate all other active subscriptions first  # noqa: E501
-                            if panel_status == "ACTIVE":
+                            if panel_status_means_active(panel_status):
                                 await session.execute(
                                     update(Subscription)
                                     .where(
@@ -622,7 +625,7 @@ async def _perform_sync_impl(
                                     "user_id": actual_user_id,
                                     "panel_user_uuid": panel_uuid,
                                     "end_date": panel_expire_at,
-                                    "is_active": panel_status == "ACTIVE",
+                                    "is_active": panel_status_means_active(panel_status),
                                     "status_from_panel": panel_status,
                                 }
                                 _include_last_connected_snapshot(
@@ -663,7 +666,7 @@ async def _perform_sync_impl(
                                     "start_date": None,
                                     "end_date": panel_expire_at,
                                     "duration_months": None,
-                                    "is_active": panel_status == "ACTIVE",
+                                    "is_active": panel_status_means_active(panel_status),
                                     "status_from_panel": panel_status,
                                     "traffic_limit_bytes": settings.user_traffic_limit_bytes,
                                     "auto_renew_enabled": False,
@@ -703,7 +706,7 @@ async def _perform_sync_impl(
                             if active_sub:
                                 update_payload = {
                                     "end_date": panel_expire_at,
-                                    "is_active": panel_status == "ACTIVE",
+                                    "is_active": panel_status_means_active(panel_status),
                                     "status_from_panel": panel_status,
                                 }
                                 _include_last_connected_snapshot(

--- a/backend/bot/payment_providers/shared/success.py
+++ b/backend/bot/payment_providers/shared/success.py
@@ -443,10 +443,15 @@ async def finalize_successful_payment(
             **activation_extra_kwargs,
         )
         if not activation or (is_subscription and not activation.get("end_date")):
+            activation_keys = (
+                tuple(sorted(str(key) for key in activation))
+                if isinstance(activation, dict)
+                else None
+            )
             logger.error(
                 "%s: activation returned no usable subscription state for payment %s"
                 " (sale_mode=%r base=%r months=%r activation_months=%r traffic_gb=%r"
-                " tariff_key=%r activation=%r).",
+                " tariff_key=%r activation_keys=%r).",
                 req.log_prefix,
                 payment_id,
                 req.sale_mode,
@@ -455,7 +460,7 @@ async def finalize_successful_payment(
                 activation_months,
                 traffic_gb_for_activation,
                 effective_tariff_key,
-                activation,
+                activation_keys,
             )
             await _mark_activation_failed(req, payment_id)
             return None

--- a/backend/bot/payment_providers/shared/success.py
+++ b/backend/bot/payment_providers/shared/success.py
@@ -444,9 +444,18 @@ async def finalize_successful_payment(
         )
         if not activation or (is_subscription and not activation.get("end_date")):
             logger.error(
-                "%s: activation returned no usable subscription state for payment %s.",
+                "%s: activation returned no usable subscription state for payment %s"
+                " (sale_mode=%r base=%r months=%r activation_months=%r traffic_gb=%r"
+                " tariff_key=%r activation=%r).",
                 req.log_prefix,
                 payment_id,
+                req.sale_mode,
+                base,
+                req.months,
+                activation_months,
+                traffic_gb_for_activation,
+                effective_tariff_key,
+                activation,
             )
             await _mark_activation_failed(req, payment_id)
             return None

--- a/backend/bot/services/panel_activity.py
+++ b/backend/bot/services/panel_activity.py
@@ -8,6 +8,24 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from db.dal import subscription_dal
 from db.models import Subscription
 
+PANEL_STATUSES_MEANING_ACTIVE = frozenset({"ACTIVE", "LIMITED"})
+
+
+def panel_status_means_active(panel_status: Any) -> bool:
+    """Whether a panel status still represents a live, paid entitlement.
+
+    ``LIMITED`` means the monthly traffic quota is exhausted, not that the
+    subscription ended: the entitlement is still valid and paid for. Mapping it
+    onto ``is_active=False`` locks the user out of the traffic top-up that
+    resolves it and drops the row out of the monthly traffic reset, so the state
+    becomes permanent. ``EXPIRED``/``DISABLED`` are genuine non-active states.
+
+    Mirrors the mapping already used by the legacy importer
+    (``scripts/legacy_import/remnashop_sales.py``).
+    """
+    return str(panel_status or "").strip().upper() in PANEL_STATUSES_MEANING_ACTIVE
+
+
 _PANEL_LAST_CONNECTED_KEYS = (
     "onlineAt",
     "online_at",

--- a/backend/bot/services/subscription_service_impl/lifecycle_details.py
+++ b/backend/bot/services/subscription_service_impl/lifecycle_details.py
@@ -4,7 +4,10 @@ from typing import Any
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from bot.services.panel_activity import record_subscription_panel_activity
+from bot.services.panel_activity import (
+    panel_status_means_active,
+    record_subscription_panel_activity,
+)
 from bot.utils.config_link import prepare_config_links
 from bot.utils.locale_defaults import tariff_premium_title
 from bot.utils.traffic_reset import (
@@ -116,7 +119,7 @@ class SubscriptionLifecycleDetailsMixin(SubscriptionServiceMixinContract):
             ):
                 update_payload_local["panel_subscription_uuid"] = panel_sub_uuid_from_panel
 
-            is_active_based_on_panel = panel_status == "ACTIVE" and (
+            is_active_based_on_panel = panel_status_means_active(panel_status) and (
                 panel_expire_dt > now if panel_expire_dt else False
             )
             if local_active_sub.is_active != is_active_based_on_panel:

--- a/backend/bot/services/subscription_service_impl/topups.py
+++ b/backend/bot/services/subscription_service_impl/topups.py
@@ -85,11 +85,28 @@ class TopupMixin(SubscriptionServiceMixinContract):
         )
         db_user = await user_dal.get_user_by_id(session, user_id)
         if not db_user or not db_user.panel_user_uuid:
+            logger.error(
+                "Traffic top-up activation has no panel identity"
+                " (payment_id=%s user_id=%s tariff_key=%s granted_gb=%s).",
+                payment_db_id,
+                user_id,
+                tariff.key,
+                granted_gb,
+            )
             return None
         sub = await subscription_dal.get_active_subscription_by_user_id(
             session, user_id, db_user.panel_user_uuid
         )
         if not sub:
+            logger.error(
+                "Traffic top-up activation found no active subscription"
+                " (payment_id=%s user_id=%s panel_user_uuid=%s tariff_key=%s granted_gb=%s).",
+                payment_db_id,
+                user_id,
+                db_user.panel_user_uuid,
+                tariff.key,
+                granted_gb,
+            )
             return None
 
         purchase_bytes = self.gb_to_bytes(granted_gb)

--- a/tests/providers/test_payment_webhook_notifications.py
+++ b/tests/providers/test_payment_webhook_notifications.py
@@ -227,11 +227,20 @@ class PaymentWebhookNotificationTests(IsolatedAsyncioTestCase):
             status="succeeded_pending_finalization",
         )
         subscription_service = SimpleNamespace(
-            activate_subscription=AsyncMock(return_value={"subscription_id": 55})
+            activate_subscription=AsyncMock(
+                return_value={
+                    "subscription_id": 55,
+                    "subscription_url": "https://panel.example/sub/secret-token",
+                }
+            )
         )
         referral_service = SimpleNamespace(apply_referral_bonuses_for_payment=AsyncMock())
 
         with (
+            self.assertLogs(
+                "bot.payment_providers.shared.success",
+                level="ERROR",
+            ) as captured_logs,
             patch(
                 "bot.payment_providers.shared.success.payment_dal.get_payment_by_db_id_for_update",
                 AsyncMock(return_value=payment),
@@ -271,6 +280,12 @@ class PaymentWebhookNotificationTests(IsolatedAsyncioTestCase):
         session.commit.assert_awaited_once()
         referral_service.apply_referral_bonuses_for_payment.assert_not_awaited()
         emit_model.assert_not_awaited()
+        rendered_logs = "\n".join(captured_logs.output)
+        self.assertIn(
+            "activation_keys=('subscription_id', 'subscription_url')",
+            rendered_logs,
+        )
+        self.assertNotIn("secret-token", rendered_logs)
 
     async def test_finalize_uses_payment_tariff_and_emits_referral_after_commit(self):
         order = []

--- a/tests/unit/test_panel_status_means_active.py
+++ b/tests/unit/test_panel_status_means_active.py
@@ -1,0 +1,63 @@
+"""Panel status -> local ``is_active`` mapping.
+
+``LIMITED`` means the monthly traffic quota is exhausted, not that the
+subscription ended. Treating it as inactive used to strand paying users: the
+row stopped satisfying ``get_active_subscription_by_user_id`` (so a traffic
+top-up could not be credited to it) *and* dropped out of
+``traffic_period_tick``'s ``is_active == True`` filter (so the monthly reset
+that would have cleared the quota never ran for it). The state was therefore
+permanent -- the user could neither wait it out nor pay to fix it.
+"""
+
+from pathlib import Path
+
+from bot.services.panel_activity import (
+    PANEL_STATUSES_MEANING_ACTIVE,
+    panel_status_means_active,
+)
+
+BACKEND = Path(__file__).resolve().parents[2] / "backend"
+
+
+def test_active_and_limited_are_the_only_active_statuses():
+    assert sorted(PANEL_STATUSES_MEANING_ACTIVE) == ["ACTIVE", "LIMITED"]
+
+
+def test_limited_still_counts_as_an_active_entitlement():
+    assert panel_status_means_active("LIMITED") is True
+
+
+def test_active_counts_as_an_active_entitlement():
+    assert panel_status_means_active("ACTIVE") is True
+
+
+def test_ended_and_blocked_statuses_do_not_count_as_active():
+    for panel_status in ("EXPIRED", "DISABLED", "INACTIVE", "TRIAL_ENDED"):
+        assert panel_status_means_active(panel_status) is False, panel_status
+
+
+def test_missing_status_does_not_count_as_active():
+    for panel_status in (None, "", "   "):
+        assert panel_status_means_active(panel_status) is False, repr(panel_status)
+
+
+def test_status_is_normalized_before_comparison():
+    for panel_status in (" limited ", "Limited", "aCtIvE"):
+        assert panel_status_means_active(panel_status) is True, repr(panel_status)
+
+
+def test_panel_status_writers_use_the_shared_mapping():
+    """Regression guard for the writers that strand LIMITED subscriptions.
+
+    Both of these modules assign the local ``is_active`` flag from the panel
+    status. A bare ``panel_status == "ACTIVE"`` there re-introduces the trap,
+    so the comparison must go through ``panel_status_means_active``.
+    """
+    writers = (
+        BACKEND / "bot" / "handlers" / "admin" / "sync_admin_runner.py",
+        BACKEND / "bot" / "services" / "subscription_service_impl" / "lifecycle_details.py",
+    )
+    for writer in writers:
+        source = writer.read_text(encoding="utf-8")
+        assert 'panel_status == "ACTIVE"' not in source, writer.name
+        assert "panel_status_means_active(" in source, writer.name


### PR DESCRIPTION
## Проблема

Панель возвращает статус `LIMITED`, когда у пользователя исчерпан месячный лимит трафика — это **не** окончание подписки. Сейчас этот статус отображается в локальный флаг `is_active = False`, и пользователь попадает в ловушку, из которой не может выйти ни сам, ни за деньги:

1. `get_active_subscription_by_user_id` фильтрует по `is_active`, поэтому `activate_topup` больше не находит подписку — и **оплаченная докупка трафика не может быть начислена**. То есть блокируется ровно та покупка, которая снимает `LIMITED`.
2. `traffic_period_tick` (`tariff_worker_regular.py`) тоже фильтрует по `is_active == True`, поэтому месячный сброс, который обнулил бы счётчик, для этой строки **никогда не выполняется**.

Из-за (2) состояние не транзиентное, а постоянное: подождать до следующего периода нельзя, потому что сброс не придёт. Из-за (1) заплатить и выйти тоже нельзя.

### Наблюдалось в продакшене

12-месячная подписка, `end_date` 2027-06-22 (валидна), `is_active = false`, `status_from_panel = LIMITED`, `traffic_used 53695625284` при `traffic_limit 53687091200`. Клиент купил докупку 50 ГБ — платёж прошёл, начисление не выполнилось, вебхук отвечал 500 на каждой повторной отправке. Ручное `is_active = true` — и та же повторная отправка сразу вернула 200, `topup_balance_bytes = 53687091200`, лимит поднялся до 100 ГБ.

### Внутреннее противоречие

Правильное отображение в проекте уже есть — в легаси-импортёре:

```python
# backend/scripts/legacy_import/remnashop_sales.py:100
"is_active": status in {"ACTIVE", "LIMITED"} and expire_at > now,
```

То есть два пути кода трактуют один и тот же статус по-разному.

## Что меняется

**Коммит 1 — `fix(sync): treat LIMITED panel status as an active subscription`**

Замысел легаси-импортёра вынесен в `panel_status_means_active()` (`bot/services/panel_activity.py`) и применён ко всем присваиваниям `is_active`, производным от статуса панели:

* три места формирования payload в `sync_admin_runner.py` (`:625`, `:666`, `:706`);
* соседняя проверка деактивации дубликатов (`:597`) — расширена **вместе** с ними намеренно: иначе у `LIMITED`-пользователя могло бы остаться две активные строки;
* то же присваивание в `lifecycle_details.py:119` — этот путь выполняется при каждом получении деталей подписки, то есть срабатывает и без запуска админской синхронизации.

`EXPIRED` и `DISABLED` по-прежнему деактивируют строку. Тесты: таблица отображения статусов + регрессионный guard на оба модуля-писателя.

**Коммит 2 — `fix(topup): log why a paid traffic top-up could not be credited`**

Оба guard-а в `activate_topup` возвращали `None` вообще без записи в лог, а `activate_subscription` теряет причину на `return result if isinstance(result, dict) else None`. Оплаченная докупка могла упасть, оставив в логе только общее «activation returned no usable subscription state». Теперь оба guard-а логируются (payment id, тариф, начисляемые ГБ), а строка отказа в общем success-пути дополнена разрешёнными входными данными (`sale_mode`, `base`, `months`, `traffic_gb`, `tariff_key`, `activation`). Поведение не меняется.

## Вопросы к обсуждению (осознанно не входят в этот PR)

1. **`activate_topup` в принципе не должен зависеть от `is_active`.** Начисление трафика — это лекарство от `LIMITED`, и требовать «активности» для него — значит ставить лекарство в зависимость от самого симптома. После этого PR симптом снят для `LIMITED`, но остальные писатели `is_active = False` (`INACTIVE`, `PANEL_USER_NOT_FOUND`, `PANEL_UPDATE_FAILED`) по-прежнему могут привести к тому же результату при валидном `end_date`.
2. **`traffic_period_tick` фильтрует по `is_active`, а не по `end_date`.** Пока фильтр такой, любая строка, ошибочно помеченная неактивной, выпадает из восстановительной джобы — то есть ошибка становится необратимой. Возможно, стоит ключевать сброс на сроке действия.

Готов сделать любой из этих пунктов отдельным PR, если такое направление устроит.

## Проверки

База: `dev` @ `5d3d16f`.

* `ruff check .` — чисто по изменённым файлам; в `dev` уже присутствуют два независимых замечания (`RUF036` в `bot/infra/promo_policies.py:63`, `LOG004` в `bot/services/config_health_service.py:576`) и одно расхождение форматирования в `docs/development/how-to.md` — не трогал, чтобы не расширять диф.
* `ruff format --check` — изменённые файлы отформатированы.
* `mypy` (полный набор целей из CI, `--explicit-package-bases`) — `Success: no issues found in 671 source files`.
* `pytest -q` — `2448 passed, 4 skipped, 221 subtests passed`.
