### PR TITLE
fix(tariffs): sync unrestricted squad access

### DIFF
--- a/backend/bot/services/tariff_worker_premium.py
+++ b/backend/bot/services/tariff_worker_premium.py
@@ -145,6 +145,10 @@ class TariffWorkerPremiumMixin(TariffWorkerPremiumUsageMixin):
                 sub.premium_is_limited = False
             return
 
+        tariff_has_premium_limit = bool(
+            int(getattr(tariff, "premium_monthly_bytes", 0) or 0) > 0
+            or getattr(tariff, "premium_topup_packages", None)
+        )
         premium_panel_user_dict = (
             panel_user_dict
             if str(getattr(tariff, "billing_model", "") or "").lower() == "period"
@@ -190,33 +194,35 @@ class TariffWorkerPremiumMixin(TariffWorkerPremiumUsageMixin):
         premium_limit = (
             premium_baseline + premium_topup_balance + premium_topup_used + premium_bonus
         )
-        if premium_limit <= 0 and not premium_unlimited_override:
-            return
-
-        node_uuids = await self._premium_node_uuids_for_tariff(tariff)
-        if not node_uuids:
-            logger.warning("Premium squads for tariff %s have no accessible nodes", tariff.key)
-            return
-
         start_date = premium_period_start.date().isoformat()
         end_date = now.date().isoformat()
-        premium_used = await self._premium_usage_for_user(
-            sub.panel_user_uuid,
-            node_uuids,
-            start_date,
-            end_date,
-            panel_username=panel_username,
-        )
-        if premium_used is None:
-            return
-        premium_used = self._premium_usage_with_partial_stats_floor(
-            sub,
-            premium_used,
-            node_uuids,
-            start_date,
-            end_date,
-            same_period=same_period,
-        )
+        unmetered_premium_access = not tariff_has_premium_limit
+        if unmetered_premium_access:
+            node_uuids: list[str] = []
+            premium_used = max(0, int(getattr(sub, "premium_used_bytes", 0) or 0))
+        else:
+            node_uuids = await self._premium_node_uuids_for_tariff(tariff)
+            if not node_uuids:
+                logger.warning("Premium squads for tariff %s have no accessible nodes", tariff.key)
+                return
+
+            fresh_premium_used = await self._premium_usage_for_user(
+                sub.panel_user_uuid,
+                node_uuids,
+                start_date,
+                end_date,
+                panel_username=panel_username,
+            )
+            if fresh_premium_used is None:
+                return
+            premium_used = self._premium_usage_with_partial_stats_floor(
+                sub,
+                fresh_premium_used,
+                node_uuids,
+                start_date,
+                end_date,
+                same_period=same_period,
+            )
 
         panel_next_reset_at = self._panel_next_traffic_reset_at(
             premium_panel_user_dict,
@@ -224,7 +230,7 @@ class TariffWorkerPremiumMixin(TariffWorkerPremiumUsageMixin):
             fallback_strategy=effective_strategy,
         )
 
-        if not premium_unlimited_override:
+        if not premium_unlimited_override and not unmetered_premium_access:
             # Consume paid top-up balance only for overflow beyond baseline+bonus.
             # Admin-granted bonus is "spent" against usage first along with baseline,
             # so the user's paid top-up survives longer.
@@ -239,7 +245,11 @@ class TariffWorkerPremiumMixin(TariffWorkerPremiumUsageMixin):
                     premium_baseline + premium_topup_balance + premium_topup_used + premium_bonus
                 )
 
-        should_limit = False if premium_unlimited_override else premium_used >= premium_limit
+        should_limit = (
+            False
+            if premium_unlimited_override or unmetered_premium_access
+            else premium_used >= premium_limit
+        )
         access_state_changed = bool(sub.premium_is_limited) != should_limit
         managed_squads = self.subscription_service._panel_squads_for_tariff(
             tariff,
@@ -338,7 +348,11 @@ class TariffWorkerPremiumMixin(TariffWorkerPremiumUsageMixin):
         sub.premium_used_bytes = int(premium_used)
         sub.premium_is_limited = bool(should_limit)
         sub.premium_period_start_at = premium_period_start
-        if not premium_unlimited_override and not is_trial_premium_tariff:
+        if (
+            not premium_unlimited_override
+            and not unmetered_premium_access
+            and not is_trial_premium_tariff
+        ):
             await self._maybe_warn_premium_squad_limit(
                 session,
                 sub,
@@ -349,7 +363,11 @@ class TariffWorkerPremiumMixin(TariffWorkerPremiumUsageMixin):
                 next_reset_at=panel_next_reset_at,
             )
         if not panel_needs_update:
-            if not premium_unlimited_override and not is_trial_premium_tariff:
+            if (
+                not premium_unlimited_override
+                and not unmetered_premium_access
+                and not is_trial_premium_tariff
+            ):
                 await self._maybe_send_premium_reset_notice(
                     session,
                     sub,
@@ -388,7 +406,11 @@ class TariffWorkerPremiumMixin(TariffWorkerPremiumUsageMixin):
         )
         if updated_panel_user and not updated_panel_user.get("error"):
             self._remember_premium_squad_match(squad_match_cache_key)
-            if not premium_unlimited_override and not is_trial_premium_tariff:
+            if (
+                not premium_unlimited_override
+                and not unmetered_premium_access
+                and not is_trial_premium_tariff
+            ):
                 await self._maybe_send_premium_reset_notice(
                     session,
                     sub,

--- a/tests/integration/test_tariff_worker.py
+++ b/tests/integration/test_tariff_worker.py
@@ -728,6 +728,60 @@ class TariffWorkerTests(unittest.IsolatedAsyncioTestCase):
             payload = panel_service.update_user_details_on_panel.await_args.args[1]
             self.assertEqual(payload["activeInternalSquads"], ["squad-1"])
 
+    async def test_unmetered_premium_squad_is_added_to_existing_subscription(self):
+        payload = _tariffs_config_payload()
+        payload["tariffs"][0]["premium_squad_uuids"] = ["premium-squad"]
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir) / "tariffs.json"
+            config_path.write_text(json.dumps(payload), encoding="utf-8")
+
+            settings = Settings(
+                _env_file=None,
+                BOT_TOKEN="token",
+                POSTGRES_USER="app_user",
+                POSTGRES_PASSWORD="app_password",
+                TARIFFS_CONFIG_PATH=str(config_path),
+            )
+            panel_service = AsyncMock(spec=PanelApiService)
+            panel_service.update_user_details_on_panel = AsyncMock(return_value={"response": {}})
+            subscription_service = SubscriptionService(settings, panel_service)
+            worker = TariffTrafficWorker(
+                settings=settings,
+                session_factory=SimpleNamespace(),
+                panel_service=panel_service,
+                subscription_service=subscription_service,
+            )
+            sub = SimpleNamespace(
+                subscription_id=1,
+                user_id=123,
+                panel_user_uuid="panel-uuid",
+                premium_baseline_bytes=0,
+                premium_topup_balance_bytes=0,
+                premium_topup_used_bytes=0,
+                premium_used_bytes=0,
+                premium_is_limited=False,
+            )
+            tariff = settings.tariffs_config.require("standard")
+
+            await worker._sync_premium_squad_limit(
+                AsyncMock(),
+                sub,
+                tariff,
+                datetime.now(UTC),
+                panel_user_dict={"activeInternalSquads": [{"uuid": "squad-1"}]},
+                panel_view="full_fetch",
+            )
+
+            panel_service.update_user_details_on_panel.assert_awaited_once()
+            panel_payload = panel_service.update_user_details_on_panel.await_args.args[1]
+            self.assertEqual(
+                panel_payload["activeInternalSquads"],
+                ["squad-1", "premium-squad"],
+            )
+            panel_service.get_internal_squad_accessible_nodes.assert_not_awaited()
+            panel_service.get_node_users_bandwidth_stats.assert_not_awaited()
+            self.assertFalse(sub.premium_is_limited)
+
     async def test_trial_premium_limit_uses_trial_premium_traffic_limit(self):
         payload = _tariffs_config_payload()
         payload["tariffs"][0]["premium_squad_uuids"] = ["premium-squad"]


### PR DESCRIPTION
## Кратко

- Исправлена выдача premium-сквадов существующим владельцам тарифа без отдельного premium-лимита.
- Безлимитный доступ переведён на штатную синхронизацию сквадов Remnawave.
- Сохраняются обычные сквады и ручные переопределения пользователя.
- Добавлен регрессионный тест для существующей активной подписки.

## Чеклист

- [x] Я запускал `npm run check` или `make check`.
- [x] Если менялись контракты, я регенерировал сгенерированные артефакты.
- [x] Я не редактировал сгенерированные артефакты вручную.
- [x] Я сохранил HTTP envelope `{"ok": ...}`, формы payload'ов событий и сигнатуры подписчиков плагинов.
- [x] Я не редактировал и не переупорядочивал существующие миграции БД.
- [x] Для изменения поведения я добавил или обновил точечные тесты.

## Сгенерированные артефакты

- [x] Не применимо
- [ ] `docs/openapi.json`
- [ ] `frontend/src/lib/api/openapi.generated.ts`
- [ ] `docs/architecture/events.md`
- [ ] манифест настроек