### PR TITLE
fix: reassign support history when merging accounts

### DIFF
--- a/backend/db/dal/user_merge_dal.py
+++ b/backend/db/dal/user_merge_dal.py
@@ -466,6 +466,28 @@ async def merge_users(
         .values(referred_by_id=target_user_id)
     )
 
+    # Support history and verification codes reference users(user_id) with a
+    # plain foreign key -- no ON DELETE clause, and User declares no
+    # relationship for them, so neither the database nor the ORM moves them
+    # implicitly. Leaving them behind makes the delete below raise
+    # ForeignKeyViolationError and rolls the whole merge back, which is what a
+    # customer who opened a ticket before linking their email would hit.
+    await session.execute(
+        update(SupportTicket)
+        .where(SupportTicket.user_id == source_user_id)
+        .values(user_id=target_user_id)
+    )
+    await session.execute(
+        update(SupportTicketMessage)
+        .where(SupportTicketMessage.author_user_id == source_user_id)
+        .values(author_user_id=target_user_id)
+    )
+    await session.execute(
+        update(EmailVerificationCode)
+        .where(EmailVerificationCode.target_user_id == source_user_id)
+        .values(target_user_id=target_user_id)
+    )
+
     await session.delete(source)
     await session.flush()
     await session.refresh(target)

--- a/tests/unit/test_user_dal.py
+++ b/tests/unit/test_user_dal.py
@@ -368,10 +368,126 @@ class UserDalMergeTests(unittest.IsolatedAsyncioTestCase):
         self.assertIn("legacy_referral_codes", update_tables)
         self.assertIn("legacy_import_mappings", update_tables)
         self.assertIn("message_logs", update_tables)
+        self.assertIn("support_tickets", update_tables)
+        self.assertIn("support_ticket_messages", update_tables)
+        self.assertIn("email_verification_codes", update_tables)
         self.assertIn("users", update_tables)
         self.assertIn("user_payment_methods", delete_tables)
         self.assertNotIn("promo_code_activations", delete_tables)
+        self.assertNotIn("support_tickets", delete_tables)
         session.delete.assert_awaited_once_with(source)
+
+    async def test_merge_users_reassigns_support_history_before_deleting_source(self):
+        """A source account that opened a support ticket must still merge.
+
+        ``support_tickets.user_id`` and ``support_ticket_messages.author_user_id``
+        are plain foreign keys with no ``ON DELETE`` clause, and ``User`` declares
+        no relationship for them, so nothing reassigns or cascades them
+        implicitly. Deleting the source row while a ticket still points at it
+        raises ``ForeignKeyViolationError`` and the whole merge is rolled back --
+        the user simply cannot link their email. The same holds for
+        ``email_verification_codes.target_user_id``.
+        """
+
+        source = SimpleNamespace(
+            user_id=-8795979672785453,
+            email="user@example.com",
+            telegram_id=None,
+            panel_user_uuid=None,
+            email_verified_at=datetime.now(UTC),
+            username=None,
+            first_name=None,
+            last_name=None,
+            language_code="ru",
+            telegram_photo_url=None,
+            channel_subscription_verified=None,
+            channel_subscription_checked_at=None,
+            channel_subscription_verified_for=None,
+            lifetime_used_traffic_bytes=None,
+            referred_by_id=None,
+            referral_code="YESHX7KVN",
+        )
+        target = SimpleNamespace(
+            user_id=850641041,
+            email=None,
+            telegram_id=850641041,
+            panel_user_uuid="panel-target",
+            email_verified_at=None,
+            username="avtozen",
+            first_name="Target",
+            last_name=None,
+            language_code="ru",
+            telegram_photo_url=None,
+            channel_subscription_verified=None,
+            channel_subscription_checked_at=None,
+            channel_subscription_verified_for=None,
+            lifetime_used_traffic_bytes=None,
+            referred_by_id=None,
+            referral_code=None,
+        )
+
+        events: list[str] = []
+
+        async def _execute(stmt):
+            if isinstance(stmt, Update):
+                events.append(f"update:{stmt.table.name}")
+            elif isinstance(stmt, Delete):
+                events.append(f"delete:{stmt.table.name}")
+            return FakeResult()
+
+        async def _delete(obj):
+            events.append("delete_source_row")
+
+        session = SimpleNamespace(
+            execute=AsyncMock(side_effect=_execute),
+            delete=AsyncMock(side_effect=_delete),
+            flush=AsyncMock(),
+            refresh=AsyncMock(),
+        )
+
+        with (
+            patch(
+                "db.dal.user_merge_dal._lock_users_for_merge",
+                AsyncMock(return_value=(source, target)),
+            ),
+            patch("db.dal.user_merge_dal._get_active_subscription_for_user", return_value=None),
+            patch("db.dal.user_merge_dal._get_latest_subscription_for_user", return_value=None),
+        ):
+            await user_dal.merge_users(
+                session,
+                source_user_id=source.user_id,
+                target_user_id=target.user_id,
+                reason="email_link",
+            )
+
+        source_row_delete = events.index("delete_source_row")
+        for table in (
+            "support_tickets",
+            "support_ticket_messages",
+            "email_verification_codes",
+        ):
+            with self.subTest(table=table):
+                self.assertIn(
+                    f"update:{table}",
+                    events,
+                    f"{table} rows are never moved off the source account",
+                )
+                self.assertLess(
+                    events.index(f"update:{table}"),
+                    source_row_delete,
+                    f"{table} must be reassigned before the source row is deleted",
+                )
+
+        statements = [call.args[0] for call in session.execute.await_args_list]
+        by_table = {stmt.table.name: stmt for stmt in statements if isinstance(stmt, Update)}
+        ticket_sql = str(
+            by_table["support_tickets"].compile(
+                dialect=postgresql.dialect(),
+                compile_kwargs={"literal_binds": True},
+            )
+        ).upper()
+        self.assertIn(f"SET USER_ID={target.user_id}", ticket_sql.replace(" = ", "="))
+        self.assertIn(f"USER_ID = {source.user_id}", ticket_sql)
 
     async def test_merge_users_rejects_duplicate_promo_redemptions(self):
         source = SimpleNamespace(


### PR DESCRIPTION
# fix: reassign support history when merging accounts

**Branch:** `fix/merge-users-support-tickets` → `dev`

---

## Кратко

- `merge_users` не переносит `support_tickets.user_id`,
  `support_ticket_messages.author_user_id` и
  `email_verification_codes.target_user_id` на целевой аккаунт, после чего
  удаляет исходную строку `users` → `ForeignKeyViolationError`.
- Практическое следствие: пользователь, который писал в поддержку из
  веб-аккаунта (без Telegram), больше **никогда** не может привязать email —
  `POST /api/account/email/verify` стабильно отвечает 500.
- Фикс переносит эти три таблицы перед `session.delete(source)`; ровно так же,
  как это уже делает `delete_user_and_relations` в том же модуле.

---

## Проблема

`merge_users` (`backend/db/dal/user_merge_dal.py:188`) переносит на целевой
аккаунт подписки, платежи, промо-активации, способы оплаты, биллинг,
ad-attributions, аватары, legacy-коды, import-mappings, оба FK `message_logs`
и `users.referred_by_id` — а затем удаляет исходную строку (`:469`).

Три таблицы не переносятся вообще:

| Таблица | Колонка | FK |
|---|---|---|
| `support_tickets` | `user_id` | `ForeignKey("users.user_id")`, без `ondelete` |
| `support_ticket_messages` | `author_user_id` | `ForeignKey("users.user_id")`, без `ondelete` |
| `email_verification_codes` | `target_user_id` | `ForeignKey("users.user_id")`, без `ondelete` |

`User` не объявляет для них `relationship`, поэтому ORM-каскада тоже нет.
Если у исходного аккаунта есть хотя бы один тикет, `session.delete(source)`
падает:

```
asyncpg.exceptions.ForeignKeyViolationError: update or delete on table "users"
violates foreign key constraint "support_tickets_user_id_fkey" on table "support_tickets"
DETAIL:  Key (user_id)=(-8795979672785453) is still referenced from table "support_tickets".
```

## Как это выглядит для пользователя

Сценарий полностью воспроизводим на проде:

1. Пользователь заходит на сайт и логинится по email → создаётся
   email-native аккаунт (синтетический отрицательный `user_id`).
2. Оттуда же пишет в поддержку — «как скачать VPN и привязать подписку».
3. Позже открывает мини-приложение в Telegram и пытается привязать тот же
   email. Роут `account_email_verify_route` (`account.py:176`) вызывает
   `merge_users`, тот падает на FK, `except Exception` делает `rollback()` и
   возвращает 500 `link_failed`.

Код при этом отправляется штатно (`/api/account/email/request` → 200), так
что со стороны пользователя всё выглядит как «правильный код не принимается».
Повторы не помогают — падение детерминированное. Обходного пути в UI нет.

Отдельно стоит отметить: `merge_users(send_user_email=True)` эмитит
`AccountMergedPayload` **до** коммита вызывающего роута, поэтому письмо
«аккаунты объединены» может уйти при merge, который затем откатился. В этом PR
не трогаю — при желании вынесу в отдельный.

## Решение

Перед `session.delete(source)` добавлены три bulk-update — тот же приём и тот
же порядок, что и в остальной функции. Новых импортов не требуется:
`SupportTicket`, `SupportTicketMessage` и `EmailVerificationCode` уже
импортированы в модуле — они используются в `delete_user_and_relations`
(`:492`) под комментарием *«Clean up dependent tables that do not cascade
automatically»*. То есть в соседней функции этот класс зависимостей уже
разобран корректно; `merge_users` просто отставал.

Тикеты и переписка сохраняются и переезжают на объединённый аккаунт — для
поддержки это важнее, чем удалить их, и это единственный вариант,
согласованный с семантикой merge (в отличие от `delete_user_and_relations`,
где удаление уместно).

## Тесты

`tests/unit/test_user_dal.py`:

- Новый `test_merge_users_reassigns_support_history_before_deleting_source` —
  проверяет, что все три таблицы обновляются **и что это происходит до**
  удаления исходной строки (порядок здесь и есть суть бага), плюс что
  `UPDATE support_tickets` действительно ставит `user_id` цели по `user_id`
  источника.
- Расширен существующий `test_merge_users_uses_bulk_updates_for_related_tables`:
  три таблицы добавлены в список ожидаемых update'ов, и добавлена проверка,
  что `support_tickets` не попадает в delete'ы.

На неисправленном `merge_users` новый тест падает (3 subtest'а), на
исправленном — проходит. Полный `tests/unit`: **1400 passed**.
`ruff format --check`, `ruff check` и `mypy backend/db/dal/user_merge_dal.py`
чистые.

## Чеклист

- [x] Я запускал `npm run check` или `make check`. *(прогнаны `tests/unit`,
      `ruff format --check`, `ruff check`, `mypy` по затронутому модулю;
      полный `make check` поднимает Postgres + Redis и frontend-гейты)*
- [x] Если менялись контракты, я регенерировал сгенерированные артефакты. *(контракты не менялись)*
- [x] Я не редактировал сгенерированные артефакты вручную.
- [x] Я сохранил HTTP envelope `{"ok": ...}`, формы payload'ов событий и сигнатуры подписчиков плагинов.
- [x] Я не редактировал и не переупорядочивал существующие миграции БД.
- [x] Для изменения поведения я добавил или обновил точечные тесты.

## Сгенерированные артефакты

- [x] Не применимо

---

## Заметка для мейнтейнера: смежная находка (в этот PR не входит)

`User` объявляет
`panel_squad_overrides = relationship("UserPanelSquadOverride", cascade="all, delete-orphan")`,
поэтому при merge оверрайды исходного аккаунта **молча удаляются**, а не
переносятся. Это не падение, а тихая потеря данных, и лечится иначе (перенос
или осознанное решение удалять). Готов сделать отдельным PR, если подтвердите
желаемое поведение.
