### PR TITLE
fix(webapp): Исправить невозможность ввода промокода в checkout

### DIFF
--- a/frontend/e2e/webapp-smoke.spec.ts
+++ b/frontend/e2e/webapp-smoke.spec.ts
@@ -1694,6 +1694,33 @@ test("checkout sliders keep price animations bounded and defer quotes while drag
   await closeDialog(dialog);
 });
 
+test("checkout promo code is editable and applies its quoted discount", async ({ page }) => {
+  await page.setViewportSize(DESKTOP_VIEWPORT);
+  await page.goto("/demo/runtime/home?mock=checkout-no-addons");
+  await expect(page.locator("nav.bottom-nav")).toBeVisible();
+  expect(await clickFirstVisibleEnabled(webappAction(page, "open-payment"))).toBe(true);
+
+  const dialog = page.locator(".dialog-card.webapp-payment-dialog");
+  await expect(dialog).toBeVisible();
+  const tariffRows = dialog.locator(".tariff-row");
+  if ((await tariffRows.count()) > 0) {
+    await tariffRows.first().click();
+    const nextButton = dialog.locator(".payment-submit-button").first();
+    if (!(await nextButton.isDisabled())) await nextButton.click();
+  }
+
+  const promoInput = dialog.locator(".checkout-promo-input");
+  await expect(promoInput).toBeEditable();
+  await promoInput.fill("save20");
+  await expect(dialog.getByRole("button", { name: "Применить", exact: true })).toBeEnabled();
+
+  await dialog.getByRole("button", { name: "Применить", exact: true }).click();
+
+  await expect(promoInput).toHaveValue("SAVE20");
+  await expect(promoInput).toHaveAttribute("readonly", "");
+  await expect(dialog.locator(".checkout-promo-discount-marker")).toBeVisible();
+});
+
 test("webapp and admin sections, dialogs, tabs stay interactive without console errors", async ({
   page,
 }) => {

--- a/frontend/src/lib/components/ui/input.svelte
+++ b/frontend/src/lib/components/ui/input.svelte
@@ -13,6 +13,7 @@
     | "maxlength"
     | "autocomplete"
     | "disabled"
+    | "readonly"
     | "class"
     | "onkeydown"
     | "oninput"
@@ -28,6 +29,7 @@
     maxlength?: HTMLInputAttributes["maxlength"];
     autocomplete?: HTMLInputAttributes["autocomplete"];
     disabled?: boolean;
+    readonly?: boolean;
     class?: string;
     onkeydown?: HTMLInputAttributes["onkeydown"];
     oninput?: HTMLInputAttributes["oninput"];
@@ -49,6 +51,7 @@
     maxlength = undefined,
     autocomplete = undefined,
     disabled = false,
+    readonly = false,
     class: className = "",
     onkeydown,
     oninput,
@@ -93,5 +96,6 @@
   {maxlength}
   {autocomplete}
   {disabled}
+  {readonly}
   {...rest}
 />

--- a/frontend/src/lib/webapp/previewMock/scenarios.ts
+++ b/frontend/src/lib/webapp/previewMock/scenarios.ts
@@ -285,7 +285,12 @@ export function applyPreviewMock(kind: unknown): void {
     return;
   }
 
-  if (mode === "checkout-addons" || mode === "checkout_addons" || mode === "subscription-extras") {
+  if (
+    mode === "checkout-addons" ||
+    mode === "checkout_addons" ||
+    mode === "subscription-extras" ||
+    mode === "checkout-no-addons"
+  ) {
     DEV_MOCK.data.settings = {
       ...DEV_MOCK.data.settings,
       traffic_mode: false,
@@ -305,12 +310,16 @@ export function applyPreviewMock(kind: unknown): void {
       premium_baseline_bytes: 53687091200,
       max_devices: 5,
     };
-    DEV_MOCK.data.plans = [
+    const plans = [
       previewPeriodPlan(1, 290, 145, "1 месяц"),
       previewPeriodPlan(3, 790, 395, "3 месяца"),
       previewPeriodPlan(6, 1490, 745, "6 месяцев"),
       previewPeriodPlan(12, 2690, 1345, "1 год"),
     ];
+    DEV_MOCK.data.plans =
+      mode === "checkout-no-addons"
+        ? plans.map(({ checkout_addons: _checkoutAddons, ...plan }) => plan)
+        : plans;
     DEV_MOCK.data.payment_methods = [
       {
         id: "cloudpayments",

--- a/frontend/src/webapp/CheckoutPromoRow.svelte
+++ b/frontend/src/webapp/CheckoutPromoRow.svelte
@@ -35,6 +35,10 @@
   const hasAppliedCode = $derived(Boolean(appliedCode));
   const statusText = $derived(String(status || "").trim());
   const markerText = $derived(statusText || t("wa_promo_applied", {}, "Applied"));
+
+  function updateValue(event: Event & { currentTarget: EventTarget & HTMLInputElement }): void {
+    value = event.currentTarget.value;
+  }
 </script>
 
 <div
@@ -48,10 +52,11 @@
       id={inputId}
       name={inputName}
       class="checkout-promo-input"
-      bind:value
+      {value}
       readonly={hasAppliedCode}
       aria-invalid={Boolean(isError && statusText)}
       placeholder={t("wa_promo_enter")}
+      oninput={updateValue}
     />
     {#if hasAppliedCode}
       <button

--- a/frontend/src/webapp/payment-dialogs/PaymentCheckoutDialog.svelte
+++ b/frontend/src/webapp/payment-dialogs/PaymentCheckoutDialog.svelte
@@ -461,10 +461,12 @@
   $effect(() => {
     const definitions = checkoutAddonDefinitions(selectedPlan);
     let resetPromo = false;
-    const supported = (kind: CheckoutAddonKind, value: number | null) =>
-      value === null ||
-      Boolean(
-        definitions[kind]?.options.some(
+    const supported = (kind: CheckoutAddonKind, value: number | null) => {
+      const definition = definitions[kind];
+      return (
+        value === null ||
+        !definition ||
+        definition.options.some(
           (option) =>
             Math.abs(
               Number(kind === "devices" ? option.extra_units || 0 : option.total_units || 0) -
@@ -472,6 +474,7 @@
             ) < 1e-9
         )
       );
+    };
     if (!supported("devices", checkoutDeviceCount)) {
       checkoutDeviceCount = 0;
       resetPromo = true;


### PR DESCRIPTION
## Что исправлено

В checkout промокод было невозможно ввести для тарифов без `checkout_addons`.

`PaymentCheckoutDialog` считал отсутствие определения add-on недопустимым состоянием, сбрасывал значения add-on’ов и вызывал `clearCheckoutPromo()`. В результате введённый текст сразу очищался.

## Изменения

- передаёт `readonly` в нативный input как boolean-проп;
- сохраняет значение промокода при вводе;
- не сбрасывает промокод, если у выбранного тарифа нет настройки add-on;
- добавляет e2e-регрессию для checkout без `checkout_addons`.

## Проверки

- `npm run check`
- `npm run test` — 590 тестов
- `npm run build`
- `npm run test:e2e` — 22 теста

`make check` запускался, но backend-тесты не собраны в текущем локальном Python: отсутствует зависимость `aiohttp_socks` на этапе collection.
